### PR TITLE
Update Dockerfiles for bolna_server, plivo_server, and twilio_server

### DIFF
--- a/local_setup/dockerfiles/bolna_server.Dockerfile
+++ b/local_setup/dockerfiles/bolna_server.Dockerfile
@@ -1,19 +1,11 @@
 FROM python:3.10.13-slim
-
 WORKDIR /app
-COPY ./requirements.txt /app
-COPY ./quickstart_server.py /app
-
-RUN apt-get update && apt-get install libgomp1 git -y
-RUN apt-get -y update && apt-get -y upgrade && apt-get install -y --no-install-recommends ffmpeg
-RUN pip install -r requirements.txt
-RUN pip install --force-reinstall git+https://github.com/bolna-ai/bolna@master
-RUN pip install scipy==1.11.0
-RUN pip install torch==2.0.1
-RUN pip install torchaudio==2.0.1
-RUN pip install pydub==0.25.1
-RUN pip install ffprobe
-RUN pip install aiofiles
-
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 \
+    git \
+    ffmpeg
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/bolna-ai/bolna@master
+COPY quickstart_server.py /app/
 EXPOSE 5001
 CMD ["uvicorn", "quickstart_server:app", "--host", "0.0.0.0", "--port", "5001"]

--- a/local_setup/dockerfiles/plivo_server.Dockerfile
+++ b/local_setup/dockerfiles/plivo_server.Dockerfile
@@ -1,11 +1,8 @@
 FROM python:3.10.13-slim
-
 WORKDIR /app
-COPY ./requirements.txt /app
-COPY ./telephony_server/plivo_api_server.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
-
-EXPOSE 8002
-
-CMD ["uvicorn", "plivo_api_server:app", "--host", "0.0.0.0", "--port", "8002"]
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=telephony_server/requirements.txt,target=/app/requirements.txt \
+    pip install --no-cache-dir -r requirements.txt
+COPY telephony_server/plivo_api_server.py /app/
+EXPOSE 8001
+CMD ["uvicorn", "plivo_api_server:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/local_setup/dockerfiles/twilio_server.Dockerfile
+++ b/local_setup/dockerfiles/twilio_server.Dockerfile
@@ -1,11 +1,8 @@
 FROM python:3.10.13-slim
-
 WORKDIR /app
-COPY ./requirements.txt /app
-COPY ./telephony_server/twilio_api_server.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
-
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=telephony_server/requirements.txt,target=/app/requirements.txt \
+    pip install --no-cache-dir -r requirements.txt
+COPY telephony_server/twilio_api_server.py /app/
 EXPOSE 8001
-
 CMD ["uvicorn", "twilio_api_server:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/local_setup/telephony_server/requirements.txt
+++ b/local_setup/telephony_server/requirements.txt
@@ -1,6 +1,7 @@
-python-dotenv==1.0.0
 fastapi==0.108.0
 plivo==4.47.0
+python-dotenv==1.0.0
 redis==5.0.1
+requests==2.31.0
 twilio==8.9.0
 uvicorn==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ python-dotenv==1.0.0
 redis==5.0.1
 requests==2.31.0
 tiktoken>=0.6.0
+torchaudio==2.0.1
 twilio==8.9.0
 uvicorn==0.22.0
 websockets==10.4


### PR DESCRIPTION
closes #355
This pull request updates the Dockerfiles for the `bolna_server`, `plivo_server`, and `twilio_server` components. The changes include updating the installation process for dependencies, such as `libgomp1`, `git`, and `ffmpeg`. Additionally, the Dockerfiles now use cache and bind mounts for improved performance.